### PR TITLE
feat(error): 전역 에러핸들러 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import uploadRouter from './src/routes/uploadRoute.js';
 import styleRouter from './src/routes/styleRoute.js';
 import curationRouter from './src/routes/curationRoute.js';
+import { AppError } from './src/utils/appError.js';
 
 dotenv.config()
 
@@ -23,5 +24,12 @@ app.use('/images', express.static(path.join(__dirname, '..', 'uploads')));//저�
 app.use('/styles', styleRouter); // 스타일 라우터 설정
 app.use('/curations', curationRouter); // Curation 라우터 설정
 app.use('/styles/:styleId/curations', curationRouter); // Curation 라우터를 스타일 라우터에 중첩
+
+app.use((err, req, res, next) => {
+    console.error(err.stack);
+    if (err instanceof AppError) {
+        return res.status(err.statusCode).json({ message: err.message });
+    }
+});
 
 app.listen(process.env.PORT || 3000, () => console.log("Server Starting..."));

--- a/src/controllers/curationControllers.js
+++ b/src/controllers/curationControllers.js
@@ -2,55 +2,38 @@ import { parse } from 'dotenv';
 import curationService from '../services/curationService.js';
 
 const curationControllers = {
-    createCuration: async (req, res) => {
+    createCuration: async (req, res, next) => {
         const createData = req.body;
 
         const styleId = parseInt(req.params.styleId);
-        const curation = await curationService.createCuration(createData, styleId);
-        res.status(200).json(curation);
+        try {
+            const curation = await curationService.createCuration(createData, styleId);
+            res.status(200).json(curation);
+        } catch (error) { next(error); }
     },
-    updateCuration: async (req, res) => {
+    updateCuration: async (req, res, next) => {
         const { password, ...updateData } = req.body;
         const curationId = parseInt(req.params.curationId);
         try {
             const curation = await curationService.updateCuration(curationId, password, updateData);
             res.status(200).send(curation);
-        } catch (error) {
-            if (error.message === 'Curation not found') {
-                res.status(404).send({ message: '존재하지 않습니다' });
-            } else if (error.message === 'Invalid password') {
-                res.status(403).send({ message: '비밀번호가 틀렸습니다' });
-            } else {
-                res.status(400).send({ message: '잘못된 요청입니다' });
-            }
-        }
+        } catch (error) { next(error); }
     },
-    deleteCuration: async (req, res) => {
+    deleteCuration: async (req, res, next) => {
         const curationId = parseInt(req.params.curationId);
         const password = req.body.password;
         try {
             await curationService.deleteCuration(curationId, password);
             res.status(200).send({ message: '큐레이팅 삭제 성공' });
-        } catch (error) {
-            if (error.message === 'Curation not found') {
-                return res.status(404).send({ message: '존재하지 않습니다' });
-            } else if (error.message === 'Invalid password') {
-                return res.status(403).send({ message: '비밀번호가 틀렸습니다' });
-            } else {
-                return res.status(400).send({ message: '잘못된 요청입니다' });
-            }
-        }
+        } catch (error) { next(error); }
     },
-    getCurationList: async (req, res) => {
+    getCurationList: async (req, res, next) => {
         try {
             const styleId = parseInt(req.params.styleId);
-            const { page = 1, pageSize = 5, searchBy='', keyword = '' } = req.query;
+            const { page = 1, pageSize = 5, searchBy = '', keyword = '' } = req.query;
             const curations = await curationService.getCurationList(styleId, parseInt(page), parseInt(pageSize), searchBy, keyword);
             res.status(200).send(curations);
-        } catch (error) {
-            console.error(error);
-            res.status(400).send({ message: '잘못된 요청입니다' });
-        }
+        } catch (error) { next(error); }
     },
 };
 

--- a/src/services/curationService.js
+++ b/src/services/curationService.js
@@ -1,4 +1,5 @@
 import { prisma } from '../utils/prismaInstance.js';
+import { AppError, ForbiddenError, NotFoundError } from '../utils/appError.js';
 
 const curationService = {
     createCuration: async (curationBody, styleId) => {
@@ -18,6 +19,7 @@ const curationService = {
                 createdAt: true,
             },
         });
+        if (!curation) { throw new NotFoundError(); }
         return curation;
     },
     updateCuration: async (curationId, password, curationBody) => {
@@ -26,8 +28,8 @@ const curationService = {
             select: { password: true },
         })
         // 비밀번호가 없거나 일치하지 않는 경우 예외 처리
-        if (!curationPassword) { throw new Error('Curation not found'); }
-        if (curationPassword.password !== password) { throw new Error('Invalid password'); }
+        if (!curationPassword) { throw new NotFoundError(); }
+        if (curationPassword.password !== password) { throw new ForbiddenError(); }
 
         const curation = await prisma.curation.update({
             where: { id: curationId },
@@ -43,6 +45,7 @@ const curationService = {
                 createdAt: true,
             },
         });
+        if (!curation) { throw new NotFoundError(); }
         return curation;
     },
     deleteCuration: async (curationId, password) => {
@@ -51,8 +54,8 @@ const curationService = {
             select: { password: true },
         });
         // 비밀번호가 없거나 일치하지 않는 경우 예외 처리
-        if (!curationPassword) { throw new Error('Curation not found'); }
-        if (curationPassword.password !== password) { throw new Error('Invalid password'); }
+        if (!curationPassword) { throw new NotFoundError(); }
+        if (curationPassword.password !== password) { throw new ForbiddenError(); }
 
         await prisma.curation.delete({
             where: { id: curationId },
@@ -68,7 +71,7 @@ const curationService = {
                     mode: 'insensitive',
                 }
             } : { styleId };
-        
+
         let curations = await prisma.curation.findMany({
             where,
             orderBy: { id: 'asc' },
@@ -94,6 +97,7 @@ const curationService = {
             },
         });
 
+        if (!curations) { throw new NotFoundError(); }
         curations = curations.map(curation => ({
             ...curation,
             comment: curation.comment || {},

--- a/src/utils/appError.js
+++ b/src/utils/appError.js
@@ -1,0 +1,27 @@
+export class AppError extends Error {
+  constructor(message, statusCode = 500) {
+    super(message);
+    this.statusCode = statusCode;
+    // 디버깅을 위한 스택 트레이스 생성
+    // 스택에서 현재 클래스의 생성자를 제외
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = '존재하지 않습니다') {
+    super(message, 404);   
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message = '잘못된 요청입니다') {
+    super(message, 400);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = '비밀번호가 틀렸습니다') {
+    super(message, 403);
+  }
+}


### PR DESCRIPTION
appError.js에서 상황에 맞는 클래스를 import해서 사용하시면 됩니다. curation api들은 에러핸들링을 사용중이니 참고하여 작성해주시길 바랍니다.

### AppError
- 서버문제, 500번대 에러같이 예상치 못한 경우를 처리하기 위한 기반 클래스.
- 다른 모든 커스텀 에러 클래스의 부모 클래스로 이 클래스를 상속받아 statusCode만 오버라이드하는 방식으로 사용합니다.

### NotFoundError
- 404 에러를 처리하기 위한 클래스

### ValidationError
- 쿼리 파라미터나 request body 에러를 처리하기 위한 클래스

### FobiddenError
- 비밀번호 검증 에러를 처리하기 위한 클래스